### PR TITLE
Refactor opacityMultiplierValue handling in IrConfigurable

### DIFF
--- a/src/main/kotlin/indent/rainbow/settings/IrConfigurable.kt
+++ b/src/main/kotlin/indent/rainbow/settings/IrConfigurable.kt
@@ -3,13 +3,24 @@ package indent.rainbow.settings
 import com.intellij.openapi.options.BoundConfigurable
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.dsl.builder.*
-import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import indent.rainbow.IrColors
 import javax.swing.JLabel
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
 class IrConfigurable : BoundConfigurable("Indent Rainbow") {
+    private val config = IrConfig.INSTANCE
+
+    private var opacityMultiplierValue: Int
+        get() = (config.opacityMultiplier * 100).roundToInt()
+        set(value) {
+            // zero (default value) if value is almost default
+            config.opacityMultiplier = if (abs(value) < 5) {
+                0F
+            } else {
+                value / 100F
+            }
+        }
 
     override fun createPanel(): DialogPanel = panel {
         row {
@@ -66,7 +77,7 @@ class IrConfigurable : BoundConfigurable("Indent Rainbow") {
                 slider.component.value = opacityMultiplierValue
             }
         )
-        slider.horizontalAlign(HorizontalAlign.FILL)
+        slider.align(Align.FILL)
     }
 
     override fun apply() {
@@ -77,20 +88,5 @@ class IrConfigurable : BoundConfigurable("Indent Rainbow") {
         IrCachedData.update(config)
         IrColors.onSchemeChange()
         IrColors.refreshEditorIndentColors()
-    }
-
-    companion object {
-        private val config = IrConfig.INSTANCE
-
-        private var opacityMultiplierValue: Int
-            get() = (config.opacityMultiplier * 100).roundToInt()
-            set(value) {
-                // zero (default value) if value is almost default
-                config.opacityMultiplier = if (abs(value) < 5) {
-                    0F
-                } else {
-                    value / 100F
-                }
-            }
     }
 }


### PR DESCRIPTION
Fix Indent Rainbow Settings Configuration
Changes
Improved opacity slider behavior in the Indent Rainbow settings panel
Enhanced custom color palette validation and default handling
Fixed slider value synchronization to prevent "Apply" button from remaining active when values are close to zero
Technical Details
Updated opacityMultiplierValue setter to handle near-zero values as default (within 5% threshold)
Added proper slider value reset in the binding to maintain UI consistency
Improved custom palette fallback logic to reset to default palette type when using default colors